### PR TITLE
extract global socket error to override the visible pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,15 +41,25 @@ function App() {
             <Game character={character} onChange={changeCharacter}/>
         </InitiativeProvider>;
 
-    if(account)
+    if (account)
         return <Tables
             account={account}
-            onJoin={(id) => {setSocketError(""); socket.emit("join", id);}}
-            onCreate={(name, table, pw) => {setSocketError(""); socket.emit("create", name, table, pw);}} />;
+            onJoin={(id) => {
+                socket.emit("join", id);
+            }}
+            onCreate={(name, table, pw) => {
+                socket.emit("create", name, table, pw);
+            }}
+        />;
 
     return <Login
-            onLogin={(name, pw) => {setSocketError(""); socket.emit("login", name, pw);}}
-            onRegister={(name, pw) => {setSocketError(""); socket.emit("register", name, pw);}} />;
+        onLogin={(name, pw) => {
+            socket.emit("login", name, pw);
+        }}
+        onRegister={(name, pw) => {
+            socket.emit("register", name, pw);
+        }}
+    />;
 }
 
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import characterDefaults from "./data/character.json";
 
 import socket, {onAccountChange, onCharacterChange, onError, saveCharacter} from "./socket";
 import InitiativeProvider from "./provider/InitiativeProvider";
+import {Alert, Box, Stack} from "@mui/material";
 
 function App() {
     const [character, setCharacter] = useState<CharacterType|null>(null);
@@ -19,30 +20,36 @@ function App() {
     }), []);
 
     const [account, setAccount] = useState<AccountType|null>(null);
-    const [error, setError] = useState<string>("");
+    const [socketError, setSocketError] = useState<string>();
 
     useEffect(() => {
         onCharacterChange(c => setCharacter({...characterDefaults, ...c}));
         onAccountChange(setAccount);
-        onError(setError);
+        onError(setSocketError);
     }, []);
+
+    if (socketError) {
+        return (
+            <Box margin={4}>
+                <Alert severity="error">{socketError}</Alert>
+            </Box>
+        );
+    }
 
     if (character)
         return <InitiativeProvider stats={character}>
-            <Game error={error} character={character} onChange={changeCharacter}/>
+            <Game character={character} onChange={changeCharacter}/>
         </InitiativeProvider>;
 
     if(account)
         return <Tables
-            error={error}
             account={account}
-            onJoin={(id) => {setError(""); socket.emit("join", id);}}
-            onCreate={(name, table, pw) => {setError(""); socket.emit("create", name, table, pw);}} />;
+            onJoin={(id) => {setSocketError(""); socket.emit("join", id);}}
+            onCreate={(name, table, pw) => {setSocketError(""); socket.emit("create", name, table, pw);}} />;
 
     return <Login
-            error={error}
-            onLogin={(name, pw) => {setError(""); socket.emit("login", name, pw);}}
-            onRegister={(name, pw) => {setError(""); socket.emit("register", name, pw);}} />;
+            onLogin={(name, pw) => {setSocketError(""); socket.emit("login", name, pw);}}
+            onRegister={(name, pw) => {setSocketError(""); socket.emit("register", name, pw);}} />;
 }
 
 export default App;

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -38,7 +38,7 @@ function emptyPool(pool: DicePoolType) {
         (pool.injury ?? 0) < 1;
 }
 
-function Game({character, error, onChange}: GameProps) {
+function Game({character, onChange}: GameProps) {
     const [locked, setLocked] = useState(false);
     const [roll, setRoll] = useState<RollConfig>({
         show: false, attribute: 0, skill: 0, modifier: 0, metadata: {}, support: false
@@ -93,8 +93,6 @@ function Game({character, error, onChange}: GameProps) {
         : calculatePool(roll.attribute, roll.skill, roll.modifier);
 
     return (<Container maxWidth="xl">
-        {(error) && <Alert severity="error">{error}</Alert>}
-
         <RollResult/>
 
         <Modal open={roll.show} onClose={resetRoll}>

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -10,12 +10,11 @@ interface LoginData {
 }
 
 interface LoginProps {
-    error?: string;
     onLogin: (name: string, pw: string) => void;
     onRegister: (name: string, pw: string) => void;
 }
 
-function Login({onLogin, onRegister, error}: LoginProps) {
+function Login({onLogin, onRegister}: LoginProps) {
     const [data, setData] = useState<LoginData>({});
     const onChange = (name: string, value: string) => setData({...data, [name]: value});;
 
@@ -32,7 +31,7 @@ function Login({onLogin, onRegister, error}: LoginProps) {
 
     return <Paper className="paperSmall">
         <Stack spacing={2}>
-            {(data.error || error) && <Alert severity="error">{error || data.error}</Alert>}
+            {(data.error) && <Alert severity="error">{data.error}</Alert>}
             <TextInput label="Name" name="name" values={data} onChange={onChange} />
             <TextInput type="password" label="Password" name="pw" values={data} onChange={onChange} />
             <TextInput type="password" label="Repeat Password" name="pwr" values={data} onChange={onChange} />

--- a/src/Tables.tsx
+++ b/src/Tables.tsx
@@ -4,7 +4,6 @@ import {Alert, Paper, Stack} from "@mui/material";
 import {Btn, TextInput} from "./components/Form";
 
 interface TablesProps {
-    error?: string;
     account: AccountType;
     onJoin: (id: string) => void;
     onCreate: (name: string, table: string, pw: string) => void;
@@ -17,7 +16,7 @@ interface TableData {
     error?: string;
 }
 
-function Tables({account, onJoin, onCreate, error}: TablesProps) {
+function Tables({account, onJoin, onCreate}: TablesProps) {
     const [data, setData] = useState<TableData>({});
     const onChange = (name: string, value: string) => setData({...data, [name]: value});
 
@@ -35,7 +34,7 @@ function Tables({account, onJoin, onCreate, error}: TablesProps) {
 
         <Paper className="paperSmall">
             <Stack spacing={2}>
-                {(data.error || error) && <Alert severity="error">{error || data.error}</Alert>}
+                {(data.error) && <Alert severity="error">{data.error}</Alert>}
                 <TextInput label="Table Name" name="table" values={data} onChange={onChange} />
                 <TextInput label="Character Name" name="character" values={data} onChange={onChange} />
                 <TextInput type="password" label="Password" name="pw" values={data} onChange={onChange} />


### PR DESCRIPTION
Small adjustment on the global error handling. Instead of passing the global error to every child page/component, we're now handling it on the app level. If the server encounters an error, we show this prominently to the user. This change preserves the existing behavior of local error handlers for the tables and login forms.