### PR TITLE
layout adjustments for smaller screens

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -113,9 +113,9 @@ function Game({character, error, onChange}: GameProps) {
                 {tabs.map(tab => (<Tab key={tab.name} label={tab.name}/>))}
             </Tabs></Grid>
 
-            <Grid xs={4} textAlign="right" item>
+            <Grid xs={4} display="flex" alignItems="center" justifyContent="end" item>
                 <FormControlLabel control={<Checkbox  checked={locked} onChange={e => setLocked(e.target.checked)} />} label="Lock" />
-                <Btn>Logout</Btn>
+                <Btn size="small" variant="outlined" color="secondary" disabled>Logout</Btn>
             </Grid>
         </Grid>
 

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -119,7 +119,7 @@ function Game({character, error, onChange}: GameProps) {
             </Grid>
         </Grid>
 
-        <Box>{tabs[tab].content()}</Box>
+        <Box marginTop={2}>{tabs[tab].content()}</Box>
     </Container>);
 }
 

--- a/src/components/Attributes.tsx
+++ b/src/components/Attributes.tsx
@@ -18,7 +18,7 @@ export default React.memo(function Attributes({values, onChange, locked=false}: 
             const value = values[a as keyof typeof values] || 0;
 
             return (<Grid key={a} item>
-                <Value disabled={locked} name={a} label={name} value={value} onChange={onChange}/>
+                <Value disabled={locked} name={a} label={name} width={90} value={value} onChange={onChange}/>
             </Grid>);
         })}
     </Grid>);

--- a/src/components/Chapter.tsx
+++ b/src/components/Chapter.tsx
@@ -14,7 +14,7 @@ export default function({url, title, columns = true}: ChapterProps) {
         axios
             .get(url)
             .then(res => setText(res.data));
-    });
+    }, [url]);
 
     const className: string = columns ? "chapter" : "";
 

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -19,7 +19,7 @@ export const TextInput = (props: TextInputProps) => {
 
 
 
-export const Btn = (props: ButtonProps) => <Button {...props} variant="contained" />;
+export const Btn = (props: ButtonProps) => <Button variant="contained" {...props} />;
 
 interface DropdownProps extends Omit<SelectProps, 'onChange' | 'variant'>{
     id: string,

--- a/src/components/Initiative.tsx
+++ b/src/components/Initiative.tsx
@@ -44,8 +44,8 @@ export default function Initiative({ children}: InitiativeProps) {
         {ini.map(c => <Fighter {...c} onChange={update} key={c.id}/>)}
 
         <Grid item container spacing={2}>
-            <Grid item xs={6}><Btn fullWidth color="error" onClick={reset}>Reset</Btn></Grid>
-            <Grid item xs={6}><Btn fullWidth onClick={round}>New Round</Btn></Grid>
+            <Grid item xs={4}><Btn fullWidth color="error" onClick={reset}>Reset</Btn></Grid>
+            <Grid item xs={8}><Btn fullWidth onClick={round}>New Round</Btn></Grid>
         </Grid>
 
         {children}

--- a/src/components/Npc.tsx
+++ b/src/components/Npc.tsx
@@ -87,7 +87,7 @@ export default function Npc({onChange, onRemove, onRoll, locked, ...props} : Npc
     return  <Accordion  expanded={Boolean(props.expanded)} onChange={(x, e) => onChange('expanded', e)}>
         <AccordionSummary expandIcon={<ExpandMoreIcon/>}>
             <Typography variant="h6" marginRight={2}>{props.name}</Typography>
-            <Btn size="small" color={"error"} disabled={locked} onClick={removeNpc}>Remove</Btn>
+            <Btn size="small" color={"error"} variant="outlined" disabled={locked} onClick={removeNpc}>Remove</Btn>
         </AccordionSummary>
 
         <AccordionDetails>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -50,7 +50,7 @@ export default React.memo(function Skills({skills, attributes, onChange, onRoll,
 
                                 return (<TableRow key={s.name}>
                                     <TableCell>
-                                        <Value disabled={locked} name={s.name} label={s.name}
+                                        <Value width={90} disabled={locked} name={s.name} label={s.name}
                                                value={skills[s.name] || 0} onChange={onChange}/>
                                     </TableCell>
                                     <TableCell> <Stack direction="row" spacing={1}>

--- a/src/components/Value.tsx
+++ b/src/components/Value.tsx
@@ -9,6 +9,7 @@ interface ValueProps {
     onChange: (name: string, value: number) => void;
     label?: string;
     width?: number;
+    fullWidth?: boolean;
     mask?: string;
     disabled?: boolean;
 }
@@ -19,7 +20,8 @@ export default React.memo(function Value({
     onChange,
     mask,
     label = "Value",
-    width = 90,
+    width,
+    fullWidth = false,
     disabled = false
 }: ValueProps) {
     const inputProps: InputProps = {};
@@ -39,6 +41,7 @@ export default React.memo(function Value({
             variant="filled"
             sx={{width}}
             InputProps={inputProps}
+            fullWidth={fullWidth}
             size="small"/>
         <Button disabled={disabled} onClick={() => onChange(name, value + 1)}><AddIcon fontSize="small"/></Button>
     </ButtonGroup>;

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -61,7 +61,7 @@ export default React.memo(function CharacterPage({stats, onChange, onRoll, locke
     const vigilance = Math.ceil(3 + (INT + COO) / 3);
     const vigilancePool: DicePoolType = {default: 1, aptitude: vigilance};
 
-    return (<Grid container spacing={2} margin={1} direction="column">
+    return (<Grid container spacing={2} direction="column">
         <Grid item container spacing={2}>
             <Grid item container xs={3} spacing={1} direction="column">
                 <Grid item><TextInput label="Name" name="name" values={stats} onChange={onChange}/></Grid>
@@ -82,18 +82,18 @@ export default React.memo(function CharacterPage({stats, onChange, onRoll, locke
                 </Paper>
             </Grid>
             <Grid item container xs={2} spacing={1} direction="column">
-                <Grid item textAlign='right'>
-                    <Value name='currentHealth' width={128} label='Health' mask={` / ${calculateHealth(stats)}`}
+                <Grid item>
+                    <Value name='currentHealth' fullWidth label='Health' mask={` / ${calculateHealth(stats)}`}
                            value={currentHealth} onChange={onChange}/>
                 </Grid>
-                <Grid item textAlign='right'>
-                    <Value name='currentEdge' width={128} label='Edge' mask={` / ${calculateEdge(stats)}`} value={currentEdge}
+                <Grid item>
+                    <Value name='currentEdge' fullWidth label='Edge' mask={` / ${calculateEdge(stats)}`} value={currentEdge}
                            onChange={onChange}/>
                 </Grid>
-                <Grid item textAlign='right'>
-                    <Value name='exp' width={128} label='Exp' value={exp} onChange={onChange}/>
+                <Grid item>
+                    <Value name='exp' fullWidth label='Exp' value={exp} onChange={onChange}/>
                 </Grid>
-                <Grid item textAlign='right'>
+                <Grid item>
                     <Btn fullWidth className='roll-btn' onClick={() => onRoll(vigilance, 0, 0, {skill: "Vigilance"})}>
                         Vigilance
                         <DicePool {...vigilancePool} />

--- a/src/pages/Cyberware.tsx
+++ b/src/pages/Cyberware.tsx
@@ -42,18 +42,24 @@ function CyberWare({onChange, onRemove, locked, name, enabled, ...data}: CyberWa
     const removeItem = () => window.confirm("Remove Item?") && onRemove();
     const details = cyberMap[name];
 
-    return  <TableRow>
-        <TableCell>{name}</TableCell>
-        <TableCell>{details.description}</TableCell>
-        <TableCell><Checkbox onChange={e => onChange('enabled', e.target.checked)} checked={enabled} /></TableCell>
-        <TableCell>{details.cyberImmunityCost}</TableCell>
-        <TableCell>
-            <Stack direction="row" spacing={2}>
-                <TextInput name="note" values={data} onChange={onChange} />
-                <Btn color="error" disabled={locked} onClick={removeItem}>Remove</Btn>
-            </Stack>
-        </TableCell>
-    </TableRow>;
+    return  (
+        <TableRow>
+            <TableCell>
+                <Stack spacing={1} direction="column">
+                    <b>{name}</b>
+                    <div>{details.description}</div>
+                </Stack>
+            </TableCell>
+            <TableCell><Checkbox onChange={e => onChange('enabled', e.target.checked)} checked={enabled}/></TableCell>
+            <TableCell>{details.cyberImmunityCost}</TableCell>
+            <TableCell>
+                <TextInput name="note" values={data} onChange={onChange}/>
+            </TableCell>
+            <TableCell>
+                <Btn color="error" disabled={locked} variant="outlined" onClick={removeItem}>Remove</Btn>
+            </TableCell>
+        </TableRow>
+    );
 }
 
 interface CyberWarePageProps {
@@ -67,21 +73,24 @@ export default React.memo(function CyberWarePage({stats, locked, onChange} : Cyb
     const changeMalfunction =  useCallback((n: string, d: CharacterCyberMalfunction) => onChange('malfunctions', {...stats.malfunctions, [n]: d}), [stats.malfunctions]);
     const [data,setData] = useState(cyberWares[0].name);
 
-    return <Grid container spacing={2} margin={1} direction="column">
+    return <Grid container spacing={2} direction="column">
         <Grid item>
+            <h2>Installed Cyberware</h2>
+
             <TableContainer component={Paper}>
                 <Table>
                     <TableHead>
                         <TableRow>
-                            <TableCell width="20%">Name</TableCell>
-                            <TableCell width="30%">Description</TableCell>
+                            <TableCell width="40%">Name</TableCell>
                             <TableCell width="5%">Enabled</TableCell>
-                            <TableCell width="5%">Immunity</TableCell>
+                            <TableCell width="10%">Immunity</TableCell>
                             <TableCell width="40%">Notes</TableCell>
+                            <TableCell width="5%"/>
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        <Collection locked={locked} values={stats.cyberware} onChange={changeCyberWare} component={CyberWare} />
+                        <Collection locked={locked} values={stats.cyberware} onChange={changeCyberWare}
+                                    component={CyberWare}/>
                     </TableBody>
                 </Table>
             </TableContainer>
@@ -89,19 +98,25 @@ export default React.memo(function CyberWarePage({stats, locked, onChange} : Cyb
 
         <Grid item container spacing={2} alignItems="center">
             <Grid item xs={6}><Autocomplete
+                size="small"
                 value={data}
                 options={cyberWares.map((i) => i.name)}
                 onChange={(e, v) => setData(v||cyberWares[0].name)}
                 renderInput={(params) => <TextField {...params} label="Cyberware" />}/></Grid>
             <Grid item xs={2}><Btn fullWidth onClick={() => data && changeCyberWare([...stats.cyberware, {...defaults, id: uuid.v4(), name: data}])}>Add Cyberware</Btn></Grid>
-            <Grid textAlign="right" item xs={4}>
-                <Chip label={`Occupied: ${stats.cyberware.map(c => cyberMap[c.name].cyberImmunityCost).reduce((a, b) => a+b, 0)}`} />
-                &nbsp;&nbsp;
-                <Chip label={`Immunity: ${calculateImmunity(stats)}`} />
+            <Grid item container xs={4} spacing={1} justifyContent="end" direction="row">
+                <Grid item>
+                    <Chip
+                        label={`Occupied: ${stats.cyberware.map(c => cyberMap[c.name].cyberImmunityCost).reduce((a, b) => a + b, 0)}`}/>
+                </Grid>
+                <Grid item>
+                    <Chip label={`Immunity: ${calculateImmunity(stats)}`}/>
+                </Grid>
             </Grid>
         </Grid>
 
         <Grid item>
+            <h2>Cyberware Malfunctions</h2>
             <TableContainer component={Paper}>
                 <Table>
                     <TableHead>

--- a/src/pages/Inventory.tsx
+++ b/src/pages/Inventory.tsx
@@ -30,23 +30,27 @@ interface ItemProps extends InventoryItem {
 function Item({onChange, onRemove, locked, ...item}: ItemProps) {
     const removeItem = () => window.confirm("Remove Item?") && onRemove();
 
-    return  <TableRow>
-        <TableCell><Autocomplete
-            freeSolo
-            value={item.name}
-            options={items.map((i) => `${i.name} (${i.item})`)}
-            onChange={(e, v) => onChange('name', v)}
-            renderInput={(params) => <TextField onChange={e => onChange('name', e.target.value)} {...params} label="Item" />}
-        /></TableCell>
-        <TableCell><TextInput type="number" name="quantity" values={item} onChange={onChange} /></TableCell>
-        <TableCell><TextInput name="location" values={item} onChange={onChange} /></TableCell>
-        <TableCell>
-            <Stack direction="row" spacing={2}>
-                <TextInput name="note" values={item} onChange={onChange} />
-                <Btn disabled={locked} color="error" onClick={removeItem}>Remove</Btn>
-            </Stack>
-        </TableCell>
-    </TableRow>;
+    return (
+        <TableRow>
+            <TableCell>
+                <Autocomplete
+                    freeSolo
+                    value={item.name}
+                    options={items.map((i) => `${i.name} (${i.item})`)}
+                    onChange={(e, v) => onChange('name', v)}
+                    renderInput={(params) => <TextField onChange={e => onChange('name', e.target.value)} {...params} label="Item"/>}
+                />
+            </TableCell>
+            <TableCell><TextInput type="number" name="quantity" values={item} onChange={onChange}/></TableCell>
+            <TableCell><TextInput name="location" values={item} onChange={onChange}/></TableCell>
+            <TableCell>
+                <TextInput name="note" values={item} onChange={onChange}/>
+            </TableCell>
+            <TableCell>
+                <Btn disabled={locked} color="error" variant="outlined" onClick={removeItem}>Remove</Btn>
+            </TableCell>
+        </TableRow>
+    );
 }
 
 interface InventoryPageProps {
@@ -60,34 +64,52 @@ interface InventoryPageProps {
 }
 
 export default React.memo(function InventoryPage({inventory, currency, locked, onChange} : InventoryPageProps) {
-    const changeInventory = useCallback((i:any) => onChange('inventory', i), [onChange]);
-    const changeCurrency = (k: string, v: number) => onChange('currency', {...currency, [k]: v});
+    const changeInventory = useCallback((value:unknown) => onChange('inventory', value), [onChange]);
+    const changeCurrency = (key: string, value: number) => onChange('currency', {...currency, [key]: value});
 
-    return <Grid container spacing={2} margin={1} direction="column">
+    return (
+        <Grid container spacing={2} direction="column">
+            <Grid item container spacing={2} direction="row" justifyContent="end">
+                <Grid item>
+                    <Value
+                        label="Credits"
+                        name="credits"
+                        value={currency.credits}
+                        onChange={changeCurrency}
+                    />
+                </Grid>
+                <Grid item>
+                    <Value
+                        label="Assets"
+                        name="assets"
+                        value={currency.assets}
+                        onChange={changeCurrency}
+                    />
+                </Grid>
+            </Grid>
 
-        <Grid item>
-            <TableContainer component={Paper}>
-                <Table>
-                    <TableHead>
-                        <TableRow>
-                            <TableCell width="30%">Item</TableCell>
-                            <TableCell width="10%">Quantity</TableCell>
-                            <TableCell width="20%">Location</TableCell>
-                            <TableCell width="30%">Notes</TableCell>
-                        </TableRow>
-                    </TableHead>
-                    <TableBody>
-                        <Collection locked={locked} values={inventory} onChange={changeInventory} component={Item} />
-                    </TableBody>
-                </Table>
-            </TableContainer>
+            <Grid item>
+                <TableContainer component={Paper}>
+                    <Table>
+                        <TableHead>
+                            <TableRow>
+                                <TableCell width="30%">Item</TableCell>
+                                <TableCell width="10%">Quantity</TableCell>
+                                <TableCell width="20%">Location</TableCell>
+                                <TableCell width="25%">Notes</TableCell>
+                                <TableCell width="5%"/>
+                            </TableRow>
+                        </TableHead>
+                        <TableBody>
+                            <Collection locked={locked} values={inventory} onChange={changeInventory} component={Item}/>
+                        </TableBody>
+                    </Table>
+                </TableContainer>
+            </Grid>
+
+            <Grid item display="flex" justifyContent="end">
+                <Btn onClick={() => changeInventory([...inventory, {...defaults, id: uuid.v4()}])}>Add Item</Btn>
+            </Grid>
         </Grid>
-
-        <Grid item container spacing={2} alignItems="center">
-            <Grid xs={8} item><Btn onClick={() => changeInventory([...inventory, {...defaults, id: uuid.v4()}])}>Add Item</Btn></Grid>
-            <Grid xs={2} item><Value width={130} label="Credits" name="credits" value={currency.credits} onChange={changeCurrency} /></Grid>
-            <Grid xs={2} item><Value width={130} label="Assets" name="assets" value={currency.assets} onChange={changeCurrency} /></Grid>
-        </Grid>
-
-    </Grid>;
+    );
 });

--- a/src/pages/Npc.tsx
+++ b/src/pages/Npc.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import {Grid} from "@mui/material";
+import {Box, Grid} from "@mui/material";
 import Initiative from "../components/Initiative";
 import Collection from "../components/Collection";
 import NpcType from "../types/npc";
@@ -31,13 +31,15 @@ interface NpcPageProps {
 export default React.memo( function NpcPage({npcs, onChange, onRoll, locked} : NpcPageProps) {
     const addNpc = () => onChange([...npcs, {...defaults, id: uuid.v4()}]);
 
-    return (<Grid container spacing={2} margin={1}>
-        <Grid item xs={3}>
-            <Initiative />
+    return (
+        <Grid container direction="row" spacing={2}>
+            <Grid item md={3} xs={12}>
+                <Initiative/>
+            </Grid>
+            <Grid item md={9} xs={12}>
+                <Collection locked={locked} values={npcs} onChange={onChange} component={Npc} onRoll={onRoll}/>
+                <Box display="flex" justifyContent="end" marginTop={2}><Btn onClick={addNpc}>Add Npc</Btn></Box>
+            </Grid>
         </Grid>
-        <Grid item xs={9}>
-            <Collection locked={locked} values={npcs} onChange={onChange} component={Npc} onRoll={onRoll} />
-            <p><Btn onClick={addNpc}>Add Npc</Btn></p>
-        </Grid>
-    </Grid>);
+    );
 });

--- a/src/pages/Npc.tsx
+++ b/src/pages/Npc.tsx
@@ -34,9 +34,11 @@ export default React.memo( function NpcPage({npcs, onChange, onRoll, locked} : N
     return (
         <Grid container direction="row" spacing={2}>
             <Grid item md={3} xs={12}>
+                <h2>Combat</h2>
                 <Initiative/>
             </Grid>
             <Grid item md={9} xs={12}>
+                <h2>Known NPCs</h2>
                 <Collection locked={locked} values={npcs} onChange={onChange} component={Npc} onRoll={onRoll}/>
                 <Box display="flex" justifyContent="end" marginTop={2}><Btn onClick={addNpc}>Add Npc</Btn></Box>
             </Grid>

--- a/src/pages/Talents.tsx
+++ b/src/pages/Talents.tsx
@@ -37,15 +37,15 @@ export default function TalentPage({stats, locked, onChange}: TalentPageProps) {
     const addTalent= () => onChange('talents', [...stats.talents, values.talent]);
 
 
-    return (<Grid container spacing={2} margin={1} direction="column">
+    return (<Grid container spacing={2} direction="column">
         {freeTalents.length > 0 && <Grid item>
             <Paper className="career"><Grid container spacing={2}>
                 {freeTalents.map(t => <Grid xs={3} item key={t}><Paper className={"talent"}>
                     <Btn size="small" style={{float: "right"}}
                          disabled={locked} color="error"
                          onClick={() => window.confirm("Remove talent?") && removeTalent(t)}>Remove</Btn>
-                    <Typography fontWeight={"bold"}>{t}</Typography>
-                    <Typography variant={"caption"}>{talentMap[t]}</Typography>
+                    <Typography fontWeight="bold">{t}</Typography>
+                    <Typography variant="body2">{talentMap[t]}</Typography>
                 </Paper></Grid>)}
         </Grid></Paper>
         </Grid>}


### PR DESCRIPTION
Collection of small adjustments to make the app work on slightly smaller laptops. The adjustments also include some headlines to make content on the page more easily discernible. Most changes are related to the container and the grid layout within.

Before:

![image](https://github.com/user-attachments/assets/c4719e4d-8b3d-41ac-987b-cf086c2cad1a)


After

![image](https://github.com/user-attachments/assets/9a2c821e-898f-4b49-90c6-5fac7fae45af)
