### PR TITLE
Add Flow toggle mechanic

### DIFF
--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -102,8 +102,8 @@ function Game({error}: GameProps) {
     }
 
     const tabs = [
-        {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll} flow={flow} toggleFlow={() => onChange('flow', !flow)}/>},
-        {name: "Combat", content: () => <CombatPage onRoll={changeRoll} flow={flow} toggleFlow={() => onChange('flow', !flow)}/>},
+        {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll}/>},
+        {name: "Combat", content: () => <CombatPage onRoll={changeRoll}/>},
         {name: "Talents", content: () => <TalentPage />},
         {name: "Cyberware", content: () => <CyberWarePage />},
         {name: "Inventory", content: () => <InventoryPage />},

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -103,7 +103,7 @@ function Game({error}: GameProps) {
 
     const tabs = [
         {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll} flow={flow} toggleFlow={() => onChange('flow', !flow)}/>},
-        {name: "Combat", content: () => <CombatPage onRoll={changeRoll}/>},
+        {name: "Combat", content: () => <CombatPage onRoll={changeRoll} flow={flow} toggleFlow={() => onChange('flow', !flow)}/>},
         {name: "Talents", content: () => <TalentPage />},
         {name: "Cyberware", content: () => <CyberWarePage />},
         {name: "Inventory", content: () => <InventoryPage />},

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -50,7 +50,7 @@ function Game({error}: GameProps) {
     });
 
     const [tab, setTab] = React.useState(0);
-    const [flow, setFlow] = useState(false);
+    const flow = useCharacter(state => state.flow) || false;
     const changeTab = useCallback((event: React.SyntheticEvent, newValue: number) => {
         setTab(newValue);
     }, []);
@@ -82,7 +82,7 @@ function Game({error}: GameProps) {
         if(roll.support) socket.emit("roll", {aptitude: roll.attribute+mod}, roll.metadata);
         else socket.emit("roll", calculatePool(roll.attribute, roll.skill, mod), roll.metadata);
 
-        if(flowApplies) setFlow(false);
+        if(flowApplies) onChange('flow', false);
 
         if(roll.metadata?.id && roll.metadata?.ap)
             spendAp(roll.metadata.id, roll.metadata.ap);
@@ -102,7 +102,7 @@ function Game({error}: GameProps) {
     }
 
     const tabs = [
-        {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll} flow={flow} toggleFlow={() => setFlow(f => !f)}/>},
+        {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll} flow={flow} toggleFlow={() => onChange('flow', !flow)}/>},
         {name: "Combat", content: () => <CombatPage onRoll={changeRoll}/>},
         {name: "Talents", content: () => <TalentPage />},
         {name: "Cyberware", content: () => <CyberWarePage />},

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useState} from 'react';
-import {Alert, Box, Checkbox, Container, FormControlLabel, Grid, Modal, Paper, Stack, Tab, Tabs} from "@mui/material";
+import {Alert, Box, Checkbox, Container, FormControlLabel, Grid, Modal, Paper, Stack, Tab, Tabs, Typography} from "@mui/material";
 import CharacterPage from "./pages/Character";
 import LorePage from "./pages/Lore";
 import CombatPage from "./pages/Combat";
@@ -50,6 +50,7 @@ function Game({error}: GameProps) {
     });
 
     const [tab, setTab] = React.useState(0);
+    const [flow, setFlow] = useState(false);
     const changeTab = useCallback((event: React.SyntheticEvent, newValue: number) => {
         setTab(newValue);
     }, []);
@@ -68,13 +69,20 @@ function Game({error}: GameProps) {
 
     const onChange = useCharacter(state => state.update);
 
+    // Flow only applies to rolls from Character (tab 0) and Combat (tab 1), not NPC or other pages
+    const flowApplies = flow && (tab === 0 || tab === 1);
+    const flowBonus = flowApplies ? 1 : 0;
+
     const onRoll = () => {
         const weapons = useCharacter.getState().weapons;
         const ship = useTable.getState().ships.find(s => s.id === roll.metadata?.ship);
         const onChangeShip = useTable.getState().updateShip;
+        const mod = roll.modifier + flowBonus;
 
-        if(roll.support) socket.emit("roll", {aptitude: roll.attribute+roll.modifier}, roll.metadata);
-        else socket.emit("roll", calculatePool(roll.attribute, roll.skill, roll.modifier), roll.metadata);
+        if(roll.support) socket.emit("roll", {aptitude: roll.attribute+mod}, roll.metadata);
+        else socket.emit("roll", calculatePool(roll.attribute, roll.skill, mod), roll.metadata);
+
+        if(flowApplies) setFlow(false);
 
         if(roll.metadata?.id && roll.metadata?.ap)
             spendAp(roll.metadata.id, roll.metadata.ap);
@@ -94,7 +102,7 @@ function Game({error}: GameProps) {
     }
 
     const tabs = [
-        {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll}/>},
+        {name: "Character", content: () => <CharacterPage locked={locked} onRoll={changeRoll} flow={flow} toggleFlow={() => setFlow(f => !f)}/>},
         {name: "Combat", content: () => <CombatPage onRoll={changeRoll}/>},
         {name: "Talents", content: () => <TalentPage />},
         {name: "Cyberware", content: () => <CyberWarePage />},
@@ -107,8 +115,8 @@ function Game({error}: GameProps) {
     ];
 
     const pool = roll.support
-        ? {aptitude: roll.attribute+roll.modifier}
-        : calculatePool(roll.attribute, roll.skill, roll.modifier);
+        ? {aptitude: roll.attribute+roll.modifier+flowBonus}
+        : calculatePool(roll.attribute, roll.skill, roll.modifier+flowBonus);
 
     return (<Container maxWidth="xl">
         {(error) && <Alert severity="error">{error}</Alert>}
@@ -121,6 +129,7 @@ function Game({error}: GameProps) {
                     <TextInput label="Modifier" type="number" name="modifier" values={roll}
                                onChange={(k, v) => setRoll({...roll, [k]: Number(v)})}/>
                     <DicePool {...pool} large/>
+                    {flowApplies && <Typography variant="body2" color="text.secondary">Flow: +1 pool bonus</Typography>}
                     <Btn disabled={emptyPool(pool)} onClick={onRoll}>Roll!</Btn>
                 </Stack>
             </Paper>

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -20,8 +20,6 @@ import useCharacter from "../state/character";
 interface CharacterPageProps {
     onRoll: (skill: number, attribute: number, modifier?: number, metadata?: Record<string, any>) => void;
     locked?: boolean;
-    flow?: boolean;
-    toggleFlow?: () => void;
 }
 
 const derivedStyles: React.CSSProperties = {
@@ -32,9 +30,11 @@ const derivedStyles: React.CSSProperties = {
     padding: 5,
 };
 
-export default React.memo(function CharacterPage({onRoll, locked=false, flow=false, toggleFlow}: CharacterPageProps) {
+export default React.memo(function CharacterPage({onRoll, locked=false}: CharacterPageProps) {
     const stats = useCharacter();
     const onChange = useCharacter(state => state.update);
+    const flow = useCharacter(state => state.flow) || false;
+    const toggleFlow = () => onChange('flow', !flow);
 
     const {
         attributes,

--- a/src/pages/Character.tsx
+++ b/src/pages/Character.tsx
@@ -20,6 +20,8 @@ import useCharacter from "../state/character";
 interface CharacterPageProps {
     onRoll: (skill: number, attribute: number, modifier?: number, metadata?: Record<string, any>) => void;
     locked?: boolean;
+    flow?: boolean;
+    toggleFlow?: () => void;
 }
 
 const derivedStyles: React.CSSProperties = {
@@ -30,7 +32,7 @@ const derivedStyles: React.CSSProperties = {
     padding: 5,
 };
 
-export default React.memo(function CharacterPage({onRoll, locked=false}: CharacterPageProps) {
+export default React.memo(function CharacterPage({onRoll, locked=false, flow=false, toggleFlow}: CharacterPageProps) {
     const stats = useCharacter();
     const onChange = useCharacter(state => state.update);
 
@@ -99,6 +101,14 @@ export default React.memo(function CharacterPage({onRoll, locked=false}: Charact
                     <Btn fullWidth className='roll-btn' onClick={() => onRoll(vigilance, 0, 0, {skill: "Vigilance"})}>
                         Vigilance
                         <DicePool {...vigilancePool} />
+                    </Btn>
+                </Grid>
+                <Grid item>
+                    <Btn fullWidth className='roll-btn'
+                         color={flow ? "success" : "primary"}
+                         variant={flow ? "contained" : "outlined"}
+                         onClick={toggleFlow}>
+                        {flow ? "Flow active" : "Flow"}
                     </Btn>
                 </Grid>
             </Grid>

--- a/src/pages/Combat.tsx
+++ b/src/pages/Combat.tsx
@@ -30,9 +30,11 @@ armors.forEach(a => armorMap[a.armor] = a);
 
 interface CombatPageProps {
     onRoll: (skill: number, attribute: number, modifier?: number, metadata?: Record<string, any>) => void;
+    flow?: boolean;
+    toggleFlow?: () => void;
 }
 
-export default function CombatPage({onRoll} : CombatPageProps) {
+export default function CombatPage({onRoll, flow=false, toggleFlow} : CombatPageProps) {
     const locked = useLock();
     const stats = useCharacter();
     const onChange = useCharacter(state => stats.update);
@@ -126,6 +128,15 @@ export default function CombatPage({onRoll} : CombatPageProps) {
 
                 <Grid item>
                     <Btn fullWidth onClick={() => performAction(actions[data.action])}>Execute</Btn>
+                </Grid>
+
+                <Grid item>
+                    <Btn fullWidth
+                         color={flow ? "success" : "primary"}
+                         variant={flow ? "contained" : "outlined"}
+                         onClick={toggleFlow}>
+                        {flow ? "Flow active" : "Flow"}
+                    </Btn>
                 </Grid>
             </Initiative>
         </Grid>

--- a/src/pages/Combat.tsx
+++ b/src/pages/Combat.tsx
@@ -30,14 +30,14 @@ armors.forEach(a => armorMap[a.armor] = a);
 
 interface CombatPageProps {
     onRoll: (skill: number, attribute: number, modifier?: number, metadata?: Record<string, any>) => void;
-    flow?: boolean;
-    toggleFlow?: () => void;
 }
 
-export default function CombatPage({onRoll, flow=false, toggleFlow} : CombatPageProps) {
+export default function CombatPage({onRoll} : CombatPageProps) {
     const locked = useLock();
     const stats = useCharacter();
     const onChange = useCharacter(state => stats.update);
+    const flow = useCharacter(state => state.flow) || false;
+    const toggleFlow = () => onChange('flow', !flow);
 
     const actions = calculateCombatActions(stats);
     const [data,setData] = useState({

--- a/src/types/character.ts
+++ b/src/types/character.ts
@@ -88,4 +88,5 @@ export default interface CharacterType {
 
     npcs?: NpcType[];
     notes?: string;
+    flow?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds a "Flow" toggle button below the Vigilance roll button on the Character page
- When active, applies +1 pool bonus (modifier) to the next roll from the Character or Combat tabs
- Auto-deactivates after rolling; can also be manually toggled off
- Roll modal displays a subtle "Flow: +1 pool bonus" note when active

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #9 