### PR TITLE
Persist dice rolls per table

### DIFF
--- a/src/components/Combat/Injuries.tsx
+++ b/src/components/Combat/Injuries.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useState} from "react";
 import allInjuries from '../../data/injuries.json';
 import {DicePool} from "../Roll";
 import socket from "../../socket";
-import {DiceResultType} from "../../types/dice";
+import {PersistentRollEntry} from "../../types/dice";
 import {summarize} from "../RollResults";
 import * as uuid from 'uuid';
 
@@ -69,9 +69,9 @@ export default function Injuries({id, injuries, health, changeHealth, changeInju
     const mapped = injuries.map((i: string, k: number) => ({...injuryMap[i], id: i+k}));
     const diceCount = (damage-Math.max(health,0)) + modifier + mapped.reduce((v, i) => v + i.modifier, 0);
 
-    const rollCallback = (result: DiceResultType, metadata: any) => {
-        if (metadata.id !== rollId) return;
-        const summary = summarize(result);
+    const rollCallback = (entry: PersistentRollEntry) => {
+        if (entry.metadata.id !== rollId) return;
+        const summary = summarize(entry.result);
         const wounds = minion ? (summary.wound|0) + (summary.minion|0) : (summary.wound|0)
         const severity = Math.min(wounds, 7);
 

--- a/src/components/RollResults.tsx
+++ b/src/components/RollResults.tsx
@@ -1,6 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {DiceResultType} from "../types/dice";
-import * as uuid from 'uuid';
+import {DiceResultType, PersistentRollEntry} from "../types/dice";
 import {Modal, Paper, Typography} from "@mui/material";
 import socket from "../socket";
 import {DiceSymbol} from "./Roll";
@@ -30,19 +29,27 @@ export function summarize(result: DiceResultType): Record<string, number> {
     return summary;
 }
 
+function toRollEntry(entry: PersistentRollEntry): RollEntry {
+    return {
+        id: entry.id,
+        result: entry.result,
+        summary: summarize(entry.result),
+        metadata: entry.metadata || {},
+    };
+}
+
 export function RollResult({onRoll}: RollResultProps) {
     const [rolls, setRolls] = useState<RollEntry[]>([]);
     const [details, setDetails] = useState<RollEntry|null>(null);
 
     useEffect(() => {
         socket.removeAllListeners("roll");
-        socket.on("roll", (result, metadata) => {
-            setRolls(old => [{
-                id: uuid.v4(),
-                summary: summarize(result),
-                result,
-                metadata: metadata || {},
-            }, ...old])
+        socket.removeAllListeners("rollHistory");
+        socket.on("rollHistory", history => {
+            setRolls(history.slice().reverse().map(toRollEntry));
+        });
+        socket.on("roll", entry => {
+            setRolls(old => [toRollEntry(entry), ...old]);
         });
     }, []);
 

--- a/src/components/Ship/Malfunctions.tsx
+++ b/src/components/Ship/Malfunctions.tsx
@@ -5,7 +5,7 @@ import React, {useCallback, useState} from "react";
 import allMalfunctions from '../../data/malfunctions.json';
 import {DicePool} from "../Roll";
 import socket from "../../socket";
-import {DiceResultType} from "../../types/dice";
+import {PersistentRollEntry} from "../../types/dice";
 import {summarize} from "../RollResults";
 import * as uuid from 'uuid';
 import {ShipType} from "../../types/ship";
@@ -75,9 +75,9 @@ export default function Malfunctions({id, ship, changeHull, changeMalfunctions}:
         malfunctionModifier += 2;
     const diceCount = (damage-Math.max(hull,0)) + modifier + malfunctionModifier;
 
-    const rollCallback = (result: DiceResultType, metadata: any) => {
-        if (metadata.id !== rollId) return;
-        const summary = summarize(result);
+    const rollCallback = (entry: PersistentRollEntry) => {
+        if (entry.metadata.id !== rollId) return;
+        const summary = summarize(entry.result);
         const wounds = summary.wound|0;
         const severity = Math.min(wounds, 7);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import StateManager from "./server/StateManager";
 const app = express();
 const server = http.createServer(app);
 const io = new Server<ClientEvents, ServerEvents, DefaultEventsMap, SocketData>(server);
-const manager = new StateManager();
+const manager = new StateManager(io);
 const port = 3080;
 
 console.log('Server started...');
@@ -19,6 +19,7 @@ touch( 'data');
 touch( 'data/accounts');
 touch( 'data/chars');
 touch('data/tables');
+touch('data/rolls');
 
 app.use(express.static(path.join(__dirname, '..', 'build')));
 app.use(express.json());

--- a/src/server/RollService.ts
+++ b/src/server/RollService.ts
@@ -1,0 +1,25 @@
+import * as fs from "fs";
+import {PersistentRollEntry} from "../types/dice";
+
+const dir = "data/rolls";
+const MAX_ROLLS = 50;
+
+export default class RollService {
+    private file(tableId: string) {
+        return `${dir}/${tableId}.json`;
+    }
+
+    load(tableId: string): PersistentRollEntry[] {
+        const file = this.file(tableId);
+        if (!fs.existsSync(file)) return [];
+        const content = fs.readFileSync(file);
+        return JSON.parse(content.toString()) as PersistentRollEntry[];
+    }
+
+    append(tableId: string, entry: PersistentRollEntry) {
+        const entries = this.load(tableId);
+        entries.push(entry);
+        const trimmed = entries.slice(-MAX_ROLLS);
+        fs.writeFileSync(this.file(tableId), JSON.stringify(trimmed));
+    }
+}

--- a/src/server/StateManager.ts
+++ b/src/server/StateManager.ts
@@ -1,25 +1,37 @@
-import {ClientEvents, ClientSocket, ServerEvents} from "../types/server";
+import {ClientEvents, ClientSocket, ServerEvents, SocketData} from "../types/server";
 import AccountService from "./AccountService";
 import CharacterService from "./CharacterService";
 import TableService from "./TableService";
 import CharacterType from "../types/character";
 import GameService from "./GameService";
-import {EventNames} from "socket.io/dist/typed-events";
+import RollService from "./RollService";
+import {DefaultEventsMap, EventNames} from "socket.io/dist/typed-events";
+import {Server} from "socket.io";
 import {TableType} from "../types/table";
+import {PersistentRollEntry} from "../types/dice";
+import * as uuid from 'uuid';
 
-type OverlappingEvents = Extract<EventNames<ServerEvents>, EventNames<ClientEvents>>;
+type OverlappingEvents = Exclude<
+    Extract<EventNames<ServerEvents>, EventNames<ClientEvents>>,
+    "roll"
+>;
+type IoServer = Server<ClientEvents, ServerEvents, DefaultEventsMap, SocketData>;
 
 export default class StateManager {
+    private io: IoServer;
     private accountService: AccountService;
     private characterService: CharacterService;
     private tableService: TableService;
     private gameService: GameService;
+    private rollService: RollService;
 
-    constructor() {
+    constructor(io: IoServer) {
+        this.io = io;
         this.accountService = new AccountService();
         this.characterService = new CharacterService();
         this.tableService = new TableService();
         this.gameService = new GameService();
+        this.rollService = new RollService();
     }
 
     private wrapHandler<Args extends any[]>(
@@ -87,13 +99,15 @@ export default class StateManager {
         socket.join(character.table);
         this.registerGameHandlers(socket);
         socket.emit("character", character);
-        socket.emit("table", this.tableService.load(character.table))
+        socket.emit("table", this.tableService.load(character.table));
+        socket.emit("rollHistory", this.rollService.load(character.table));
     }
 
     private passThrough(socket: ClientSocket, event: OverlappingEvents) {
         // @ts-ignore Fuck Type Gymnastics!
         socket.on(event, this.wrapHandler(socket, (data) => {
             if (!socket.data.character) throw new Error("Invalid character!");
+            // @ts-ignore Fuck Type Gymnastics!
             socket.to(socket.data.character.table).emit(event, data);
         }));
     }
@@ -105,8 +119,14 @@ export default class StateManager {
             if (!socket.data.character) throw new Error("Character required!");
             console.log("Rolling:", socket.data.character.name, pool);
             metadata['player'] = socket.data.character.name;
-            const result = this.gameService.roll(pool);
-            socket.to(socket.data.character.table).emit("roll", result, metadata);
+            const entry: PersistentRollEntry = {
+                id: uuid.v4(),
+                timestamp: Date.now(),
+                result: this.gameService.roll(pool),
+                metadata,
+            };
+            this.rollService.append(socket.data.character.table, entry);
+            this.io.to(socket.data.character.table).emit("roll", entry);
         }));
 
         socket.on("save", this.wrapHandler(socket, (data) => {

--- a/src/types/dice.ts
+++ b/src/types/dice.ts
@@ -10,3 +10,10 @@ export type DiceResultType = {
     symbols: string[];
     exploded?: boolean;
 }[];
+
+export interface PersistentRollEntry {
+    id: string;
+    timestamp: number;
+    result: DiceResultType;
+    metadata: Record<string, any>;
+}

--- a/src/types/server.ts
+++ b/src/types/server.ts
@@ -3,7 +3,7 @@ import CharacterType from "./character";
 import {Socket as ServerSideSocket} from "socket.io";
 import {Socket as ClientSideSocket} from "socket.io-client";
 import {DefaultEventsMap} from "socket.io/dist/typed-events";
-import {DicePoolType, DiceResultType} from "./dice";
+import {DicePoolType, DiceResultType, PersistentRollEntry} from "./dice";
 import {Combatant} from "./combat";
 import {ShipType} from "./ship";
 import {TableType} from "./table";
@@ -35,7 +35,8 @@ export interface ClientEvents extends PassThroughEvents {
 export interface ServerEvents extends PassThroughEvents {
     account: (data: AccountType) => void;
     character: (data: CharacterType) => void;
-    roll: (result: DiceResultType, metadata?: Metadata) => void;
+    roll: (entry: PersistentRollEntry) => void;
+    rollHistory: (entries: PersistentRollEntry[]) => void;
     error: (message: string) => void;
 }
 


### PR DESCRIPTION
## Summary
- Dice rolls are now persisted per table at `data/rolls/<tableId>.json` (capped at the 50 most recent), so they survive browser refresh and server restart.
- Clients joining a table receive the table's roll history on character select via a new `rollHistory` event and hydrate the on-screen log with it.
- New rolls are broadcast to **everyone in the room including the sender**, so the player who rolled now sees their own result live too (previously `socket.to(room)` excluded the sender).

## Implementation notes
- New `RollService` mirrors the existing `TableService` / `CharacterService` JSON-on-disk pattern.
- Roll IDs and timestamps are now assigned server-side; the wire format for the `roll` event changed from `(result, metadata)` to a single `PersistentRollEntry` object.
- `Injuries.tsx` and `Malfunctions.tsx` listeners updated to the new entry shape.
- `data/rolls` is added to the startup `touch` calls in `src/server.ts`.

## Test plan
- [x] Open two browsers on the same character/table; roll on one — the entry appears live on **both** (sender included).
- [x] Roll several times, refresh the page, log back in and re-select character — history reappears.
- [x] Late joiner: roll on browser A, then open browser B and join the same table — B sees existing history; subsequent rolls on A appear live on B.
- [x] Per-table isolation: rolls on table X don't appear when joining table Y.
- [ ] Roll >50 times on one table; `data/rolls/<tableId>.json` stays at 50 entries.
- [x] Server restart preserves history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)